### PR TITLE
Add Snowflake SQL - Zendesk Ticket Metrics

### DIFF
--- a/zendesk_ticket_metrics/zendesk_multiple_schedules/snowflake/README.md
+++ b/zendesk_ticket_metrics/zendesk_multiple_schedules/snowflake/README.md
@@ -1,0 +1,22 @@
+## Fivetran/Zendesk: Snowflake Queries
+
+### Introduction
+The queries in this directory are based on the original queries of the same names in the above directories. These queries have been re-written for compatibility with Snowflake SQL syntax.
+
+### Important Notes
+There are a couple of limitations and caveats which you should keep in mind:
+
+* Zendesk considers Sunday to be the first day of the week, but by default Snowflake considers Monday to be the first day of the week. The `date_trunc` function, when called with the `week` argument, will therefore return a result which is incompatible with Zendesk schedule intervals. To get around this, you must set Snowflake's [WEEK_START](https://docs.snowflake.com/en/sql-reference/parameters.html#label-week-start) parameter equal to `7` (Sunday). Failure to do this will result in inaccurate calculations for certain tickets.
+* The `weekly_periods` CTE is hard-coded to allow for a maximum of 3 years (`52 * 3`). This is because arguments to Snowflake's `generator` function must be constant. If you need to report on tickets where the resolution period may approach or exceed 3 years, you will need to increase this number.
+* Tickets closed by merge (tagged with `closed_by_merge`) are missing values such as SOLVED_AT and values derived from SOLVED_AT, such as resolution time.
+* REQUESTER_UPDATED_AT is missing for "voice" tickets.
+
+### Snowflake SQL
+
+There are several functional or syntactic differences between BigQuery SQL and Snowflake SQL that are relevant to these queries. The following is a non-exhaustive list:
+- By default, Snowflake considers Monday to be the first day of the week. This is in contrast to BigQuery, which considers Sunday to be the first day. Zendesk also considers the first day of the week to be Sunday. Snowflake's behavior is configurable - see [here](https://docs.snowflake.com/en/sql-reference/functions-date-time.html#first-day-of-the-week).
+- Snowflake does not have named window partitions
+- Snowflake has no function to generate sequence arrays of arbitrary length
+- `timestamp_diff` is called `timestampdiff` in Snowflake SQL
+- Snowflake's `timestampdiff` accepts arguments in a different order: the date/time part comes first, and the timestamps themselves are reversed.
+- Snowflake uses `IFF` instead of `IF` 

--- a/zendesk_ticket_metrics/zendesk_multiple_schedules/snowflake/first_resolution_time.sql
+++ b/zendesk_ticket_metrics/zendesk_multiple_schedules/snowflake/first_resolution_time.sql
@@ -1,0 +1,87 @@
+create or replace view zendesk.first_resolution_time as (
+with ticket_schedule as (
+    select 
+        ticket.id as ticket_id
+        , ticket_schedule.schedule_id,
+        , coalesce(ticket_schedule.created_at, ticket.created_at) as schedule_created_at
+        , coalesce(lead(schedule_created_at, 1) over (partition by ticket.id order by schedule_created_at), '9999-12-31 01:01:01'::timestamp) as schedule_invalidated_at
+    from zendesk.ticket
+    inner join zendesk.brand
+        on ticket.brand_id = brand.id
+    left join zendesk.ticket_schedule
+        on ticket.id = ticket_schedule.ticket_id
+),
+ticket_first_solved_time as (
+    select 
+        ticket.id as ticket_id
+        , ticket_schedule.schedule_created_at
+        , ticket_schedule.schedule_invalidated_at
+        , ticket_schedule.schedule_id
+        , round(timestampdiff(second, date_trunc(week, ticket_schedule.schedule_created_at), ticket_schedule.schedule_created_at)/60, 0) as start_time_in_minutes_from_week
+        , greatest(0, round(timestampdiff(second, ticket_schedule.schedule_created_at, least(ticket_schedule.schedule_invalidated_at, min(ticket_field_history.updated)))/60, 0)) as raw_delta_in_minutes
+    from zendesk.ticket
+    left join ticket_schedule on ticket.id = ticket_schedule.ticket_id
+    left join zendesk.ticket_field_history on ticket.id = ticket_field_history.ticket_id
+    where ticket_field_history.value = 'solved'
+    group by 1, 2, 3, 4
+),
+weekly_periods as (
+    select
+        ticket_id
+        , start_time_in_minutes_from_week
+        , raw_delta_in_minutes
+        , row_number() over (partition by ticket_id order by 1) - 1 as week_number
+        , schedule_id
+        , greatest(0, start_time_in_minutes_from_week - week_number * (7*24*60)) as ticket_week_start_time
+        , least(start_time_in_minutes_from_week + raw_delta_in_minutes - week_number * (7*24*60), (7*24*60)) as ticket_week_end_time
+    from ticket_first_solved_time
+    /*
+    the original query used a `generate_array` function which
+    is unavailable here. we accomplish something similar by cross joining
+    a series generator with the `row_number` window function and filtering
+    the result. week_number is zero-indexed.
+    */
+    cross join table(generator(rowcount => 52 * 3)) -- can't generate arbitrary lengths, increase this number if 3 years is not enough time
+    qualify row_number() over (partition by ticket_id order by 1) - 1 <= floor((start_time_in_minutes_from_week + raw_delta_in_minutes) / (7*24*60))
+),
+intercepted_periods as (
+    select 
+        ticket_id
+        , week_number
+        , schedule_id
+        , ticket_week_start_time
+        , ticket_week_end_time
+        , schedule.start_time_utc as schedule_start_time
+        , schedule.end_time_utc as schedule_end_time
+        , least(ticket_week_end_time, schedule.end_time_utc) - greatest(ticket_week_start_time, schedule.start_time_utc) as scheduled_minutes
+    from weekly_periods
+    inner join zendesk.ticket
+        on weekly_periods.ticket_id = ticket.id
+    left join zendesk.schedule
+        on ticket_week_start_time <= schedule.end_time_utc
+        and ticket_week_end_time >= schedule.start_time_utc
+        and weekly_periods.schedule_id = schedule.id
+),
+business_minutes as (
+    select 
+        ticket_id
+        , sum(scheduled_minutes) as first_resolution_time_in_business_minutes
+    from intercepted_periods
+    group by 1
+    order by 1
+),
+calendar_minutes as (
+    select
+        ticket_id
+        , sum(raw_delta_in_minutes) as first_resolution_time_in_calendar_minutes
+    from ticket_first_solved_time
+    group by 1
+)
+select 
+    calendar_minutes.ticket_id
+    , calendar_minutes.first_resolution_time_in_calendar_minutes
+    , business_minutes.first_resolution_time_in_business_minutes
+from calendar_minutes
+left join business_minutes
+    on business_minutes.ticket_id = calendar_minutes.ticket_id
+);

--- a/zendesk_ticket_metrics/zendesk_multiple_schedules/snowflake/full_resolution_time.sql
+++ b/zendesk_ticket_metrics/zendesk_multiple_schedules/snowflake/full_resolution_time.sql
@@ -1,0 +1,85 @@
+create or replace view zendesk.full_resolution_time as (
+with ticket_schedule as (
+    select 
+        ticket.id as ticket_id
+        , ticket_schedule.schedule_id,
+        , coalesce(ticket_schedule.created_at, ticket.created_at) as schedule_created_at
+        , coalesce(lead(schedule_created_at, 1) over (partition by ticket.id order by schedule_created_at), '9999-12-31 01:01:01'::timestamp) as schedule_invalidated_at
+    from zendesk.ticket
+    inner join zendesk.brand
+        on ticket.brand_id = brand.id
+    left join zendesk.ticket_schedule
+        on ticket.id = ticket_schedule.ticket_id
+),
+ticket_full_solved_time as (
+    select 
+        ticket.id as ticket_id
+        , ticket_schedule.schedule_created_at
+        , ticket_schedule.schedule_invalidated_at
+        , ticket_schedule.schedule_id
+        , round(timestampdiff(second, date_trunc(week, ticket_schedule.schedule_created_at), ticket_schedule.schedule_created_at)/60, 0) as start_time_in_minutes_from_week
+        , greatest(0, round(timestampdiff(second, ticket_schedule.schedule_created_at, least(ticket_schedule.schedule_invalidated_at, max(ticket_field_history.updated)))/60, 0)) as raw_delta_in_minutes
+    from zendesk.ticket
+    left join ticket_schedule on ticket.id = ticket_schedule.ticket_id
+    left join zendesk.ticket_field_history on ticket.id = ticket_field_history.ticket_id
+    where ticket_field_history.value = 'solved'
+    group by 1, 2, 3, 4
+),
+weekly_periods as (
+    select
+        ticket_id
+        , start_time_in_minutes_from_week
+        , raw_delta_in_minutes
+        , row_number() over (partition by ticket_id order by 1) - 1 as week_number
+        , schedule_id
+        , greatest(0, start_time_in_minutes_from_week - week_number * (7*24*60)) as ticket_week_start_time
+        , least(start_time_in_minutes_from_week + raw_delta_in_minutes - week_number * (7*24*60), (7*24*60)) as ticket_week_end_time
+    from ticket_full_solved_time
+    /*
+    fivetran's original query used a `generate_array` function which
+    is unavailable here. we accomplish something similar by cross joining
+    a series generator with the `row_number` window function and filtering
+    the result. week_number is zero-indexed.
+    */
+    cross join table(generator(rowcount => 52 * 3)) -- can't generate arbitrary lengths, increase this number if 3 years is not enough time
+    qualify row_number() over (partition by ticket_id order by 1) - 1 <= floor((start_time_in_minutes_from_week + raw_delta_in_minutes) / (7*24*60))
+),
+intercepted_periods as (
+    select 
+        ticket_id
+        , week_number
+        , schedule_id
+        , ticket_week_start_time
+        , ticket_week_end_time
+        , schedule.start_time_utc as schedule_start_time
+        , schedule.end_time_utc as schedule_end_time
+        , least(ticket_week_end_time, schedule.end_time_utc) - greatest(ticket_week_start_time, schedule.start_time_utc) as scheduled_minutes
+    from weekly_periods
+    left join zendesk.schedule
+        on ticket_week_start_time <= schedule.end_time_utc
+        and ticket_week_end_time >= schedule.start_time_utc
+        and weekly_periods.schedule_id = schedule.id
+),
+business_minutes as (
+    select 
+        ticket_id
+        , sum(scheduled_minutes) as full_resolution_time_in_business_minutes
+    from intercepted_periods
+    group by 1
+    order by 1
+),
+calendar_minutes as (
+    select 
+        ticket_id
+        , sum(raw_delta_in_minutes) as full_resolution_time_in_calendar_minutes
+    from ticket_full_solved_time
+    group by 1
+)
+select 
+    calendar_minutes.ticket_id
+    , calendar_minutes.full_resolution_time_in_calendar_minutes
+    , business_minutes.full_resolution_time_in_business_minutes
+from calendar_minutes
+left join business_minutes
+    on business_minutes.ticket_id = calendar_minutes.ticket_id
+);

--- a/zendesk_ticket_metrics/zendesk_multiple_schedules/snowflake/ticket_metrics.sql
+++ b/zendesk_ticket_metrics/zendesk_multiple_schedules/snowflake/ticket_metrics.sql
@@ -1,0 +1,144 @@
+--- Create the 4 dependent views before executing this
+create or replace view zendesk.ticket_metrics as (
+WITH group_stations AS (
+    SELECT
+        ticket_id,
+        COUNT(distinct value) AS group_stations
+    FROM zendesk.ticket_field_history
+    WHERE field_name = 'group_id' 
+    GROUP BY ticket_id
+),
+assignee_stations AS (
+    SELECT
+        ticket_id,
+        COUNT(distinct value) AS assignee_stations
+    FROM zendesk.ticket_field_history
+    WHERE field_name = 'assignee_id' 
+    GROUP BY ticket_id
+),
+reopens AS (
+    SELECT 
+        ticket_id, 
+        COUNT(ticket_id) AS reopens
+    FROM ( 
+        SELECT 
+            ticket_id,
+            value AS status, 
+            LAG(value, 1) OVER (PARTITION BY ticket_id ORDER BY updated) AS prev_status
+        FROM zendesk.ticket_field_history
+        WHERE field_name = 'status' 
+    ) 
+    WHERE prev_status = 'solved' AND status = 'open' 
+    GROUP BY ticket_id
+),
+replies AS (
+    SELECT
+        ticket_id,
+        COUNT(ticket_id) AS replies
+    FROM zendesk.ticket_comment
+    JOIN zendesk.user
+        ON ticket_comment.user_id = user.id
+    WHERE
+        public
+        and user.role in ('admin', 'agent')
+    GROUP BY ticket_id
+),
+assignee_updated_at AS (
+    SELECT
+        ticket.id as ticket_id,
+        max(updated) as assignee_updated_at
+    FROM zendesk.ticket
+    JOIN zendesk.ticket_field_history 
+        ON ticket_field_history.ticket_id = ticket.id AND ticket_field_history.user_id = ticket.assignee_id
+    GROUP BY 1
+),
+requester_updated_at AS (
+    SELECT
+        ticket.id as ticket_id,
+        max(updated) as requester_updated_at
+    FROM zendesk.ticket
+    JOIN zendesk.ticket_field_history 
+        ON ticket_field_history.ticket_id = ticket.id AND ticket_field_history.user_id = ticket.requester_id
+    GROUP BY 1
+),
+status_updated_at AS (
+    SELECT
+        ticket_id,
+        MAX(updated) AS status_updated_at
+    FROM zendesk.ticket_field_history
+    WHERE field_name = 'status' 
+    GROUP BY ticket_id
+),
+initially_assigned_at AS (
+    SELECT
+        ticket_id,
+        MIN(updated) AS initially_assigned_at
+    FROM zendesk.ticket_field_history
+    WHERE field_name = 'assignee_id' 
+    GROUP BY ticket_id
+),
+assigned_at AS (
+    SELECT
+        ticket_id,
+        MAX(updated) AS assigned_at
+    FROM zendesk.ticket_field_history
+    WHERE field_name = 'assignee_id' 
+    GROUP BY ticket_id
+),
+solved_at AS (
+    SELECT
+        ticket_id,
+        MAX(updated) AS solved_at
+    FROM zendesk.ticket_field_history
+    WHERE value = 'solved' 
+    GROUP BY ticket_id
+),
+latest_comment_added_at AS (
+    SELECT
+        ticket_id,
+        MAX(created) AS latest_comment_added_at
+    FROM zendesk.ticket_comment 
+    GROUP BY ticket_id
+)
+SELECT 
+    ticket.id AS ticket_id
+    , group_stations.group_stations
+    , assignee_stations.assignee_stations
+    , coalesce(reopens.reopens, 0) as reopens
+    , coalesce(replies.replies, 0) as replies
+    , assignee_updated_at.assignee_updated_at
+    , requester_updated_at.requester_updated_at
+    , status_updated_at.status_updated_at
+    , initially_assigned_at.initially_assigned_at
+    , assigned_at.assigned_at
+    , solved_at.solved_at
+    , latest_comment_added_at.latest_comment_added_at
+    , reply_time.reply_time_in_calendar_minutes
+    , reply_time.reply_time_in_business_minutes
+    , first_resolution_time.first_resolution_time_in_calendar_minutes
+    , first_resolution_time.first_resolution_time_in_business_minutes
+    , full_resolution_time.full_resolution_time_in_calendar_minutes
+    , full_resolution_time.full_resolution_time_in_business_minutes
+    , wait_times.agent_wait_time_in_calendar_minutes
+    , wait_times.agent_wait_time_in_business_minutes
+    , wait_times.requester_wait_time_in_calendar_minutes
+    , wait_times.requester_wait_time_in_business_minutes
+    , wait_times.on_hold_time_in_calendar_minutes
+    , wait_times.on_hold_time_in_business_minutes
+FROM zendesk.ticket
+LEFT JOIN group_stations ON ticket.id = group_stations.ticket_id
+LEFT JOIN assignee_stations ON ticket.id = assignee_stations.ticket_id
+LEFT JOIN reopens ON ticket.id = reopens.ticket_id
+LEFT JOIN replies ON ticket.id = replies.ticket_id
+LEFT JOIN assignee_updated_at ON ticket.id = assignee_updated_at.ticket_id
+LEFT JOIN requester_updated_at ON ticket.id = requester_updated_at.ticket_id
+LEFT JOIN status_updated_at ON ticket.id = status_updated_at.ticket_id
+LEFT JOIN initially_assigned_at ON ticket.id = initially_assigned_at.ticket_id
+LEFT JOIN assigned_at ON ticket.id = assigned_at.ticket_id
+LEFT JOIN solved_at ON ticket.id = solved_at.ticket_id
+LEFT JOIN latest_comment_added_at ON ticket.id = latest_comment_added_at.ticket_id
+LEFT JOIN zendesk.reply_time ON ticket.id = reply_time.ticket_id
+LEFT JOIN zendesk.first_resolution_time ON ticket.id = first_resolution_time.ticket_id
+LEFT JOIN zendesk.full_resolution_time ON ticket.id = full_resolution_time.ticket_id
+LEFT JOIN zendesk.wait_times ON ticket.id = wait_times.ticket_id
+);

--- a/zendesk_ticket_metrics/zendesk_multiple_schedules/snowflake/wait_times.sql
+++ b/zendesk_ticket_metrics/zendesk_multiple_schedules/snowflake/wait_times.sql
@@ -1,0 +1,132 @@
+create or replace view zendesk.wait_times as (
+with ticket_status_timeline as (
+    select
+        ticket_id
+        , value
+        , updated as status_start
+        , coalesce(lead(updated, 1) over (partition by ticket_id order by updated), current_timestamp()) as status_end
+    from zendesk.ticket_field_history
+    where field_name = 'status'
+),
+ticket_schedule as (
+    select
+        ticket.id as ticket_id
+        , ticket_schedule.schedule_id
+        , coalesce(ticket_schedule.created_at, ticket.created_at) as schedule_created_at
+        , coalesce(lead(schedule_created_at, 1) over (partition by ticket.id order by schedule_created_at), '9999-12-31 01:01:01'::timestamp) as schedule_invalidated_at
+    from zendesk.ticket
+    inner join zendesk.brand
+        on ticket.brand_id = brand.id
+    left join zendesk.ticket_schedule
+        on ticket.id = ticket_schedule.ticket_id
+),
+ticket_status_crossed_with_schedule as (
+    select
+        ticket_status_timeline.ticket_id
+        , ticket_status_timeline.value
+        , ticket_schedule.schedule_id
+        , greatest(status_start, schedule_created_at) as status_schedule_start
+        , least(status_end, schedule_invalidated_at) as status_schedule_end
+    from ticket_status_timeline
+    left join ticket_schedule
+        on ticket_status_timeline.ticket_id = ticket_schedule.ticket_id
+    where timestampdiff(second, greatest(status_start, schedule_created_at), least(status_end, schedule_invalidated_at)) > 0
+),
+ticket_full_solved_time as (
+    select 
+        ticket_status_crossed_with_schedule.ticket_id
+        , ticket_status_crossed_with_schedule.status_schedule_start
+        , ticket_status_crossed_with_schedule.status_schedule_end
+        , ticket_status_crossed_with_schedule.schedule_id
+        , ticket_status_crossed_with_schedule.value as ticket_status
+        , round(timestampdiff(second, date_trunc(week, ticket_status_crossed_with_schedule.status_schedule_start), ticket_status_crossed_with_schedule.status_schedule_start)/60, 0) as start_time_in_minutes_from_week
+        , round(timestampdiff(second, ticket_status_crossed_with_schedule.status_schedule_start, ticket_status_crossed_with_schedule.status_schedule_end)/60, 0) as raw_delta_in_minutes
+    from ticket_status_crossed_with_schedule
+    left join ticket_schedule on ticket_schedule.ticket_id = ticket_status_crossed_with_schedule.ticket_id
+    group by 1, 2, 3, 4, 5
+),
+weekly_periods as (
+    select
+        ticket_id
+        , start_time_in_minutes_from_week
+        , raw_delta_in_minutes
+        , row_number() over (partition by ticket_id, ticket_status, status_schedule_start order by 1, 2, 3) - 1 as week_number
+        , schedule_id
+        , ticket_status
+        , greatest(0, start_time_in_minutes_from_week - week_number * (7*24*60)) as ticket_week_start_time
+        , least(start_time_in_minutes_from_week + raw_delta_in_minutes - week_number * (7*24*60), (7*24*60)) as ticket_week_end_time
+    from ticket_full_solved_time
+    /*
+    fivetran's original query used a `generate_array` function which
+    is unavailable here. we accomplish something similar by cross joining
+    a series generator with the `row_number` window function and filtering
+    the result. week_number is zero-indexed.
+    */
+    cross join table(generator(rowcount => 52 * 3)) -- can't generate arbitrary lengths, increase this number if 3 years is not enough time
+    qualify row_number() over (partition by ticket_id, ticket_status, status_schedule_start order by 1, 2, 3) - 1 <= floor((start_time_in_minutes_from_week + raw_delta_in_minutes) / (7*24*60))
+),
+intercepted_periods as (
+    select 
+        ticket_id
+        , week_number
+        , schedule_id
+        , ticket_status
+        , ticket_week_start_time
+        , ticket_week_end_time
+        , schedule.start_time_utc as schedule_start_time
+        , schedule.end_time_utc as schedule_end_time
+        , least(ticket_week_end_time, schedule.end_time_utc) - greatest(ticket_week_start_time, schedule.start_time_utc) as scheduled_minutes
+    from weekly_periods
+    left join zendesk.schedule
+        on ticket_week_start_time <= schedule.end_time_utc
+        and ticket_week_end_time >= schedule.start_time_utc
+        and weekly_periods.schedule_id = schedule.id
+),
+business_minutes as (
+    select
+        ticket_id
+        , ticket_status
+        , iff(ticket_status in ('pending'), scheduled_minutes, 0) as agent_wait_time_in_minutes
+        , iff(ticket_status in ('new', 'open', 'hold'), scheduled_minutes, 0) as requester_wait_time_in_minutes
+        , iff(ticket_status in ('hold'), scheduled_minutes, 0) as on_hold_time_in_minutes
+    from intercepted_periods
+),
+business_minutes_aggregated as (
+    select 
+        ticket_id
+        , sum(agent_wait_time_in_minutes) as agent_wait_time_in_minutes
+        , sum(requester_wait_time_in_minutes) as requester_wait_time_in_minutes
+        , sum(on_hold_time_in_minutes) as on_hold_time_in_minutes
+    from business_minutes
+    group by 1
+),
+calendar_minutes as (
+    select 
+        ticket_id
+        , ticket_status
+        , iff(ticket_status in ('pending'), raw_delta_in_minutes, 0) as agent_wait_time_in_minutes
+        , iff(ticket_status in ('new', 'open', 'hold'), raw_delta_in_minutes, 0) as requester_wait_time_in_minutes
+        , iff(ticket_status in ('hold'), raw_delta_in_minutes, 0) as on_hold_time_in_minutes
+    from ticket_full_solved_time
+),
+calendar_minutes_aggregated as (
+    select
+        ticket_id
+        , sum(agent_wait_time_in_minutes) as agent_wait_time_in_minutes
+        , sum(requester_wait_time_in_minutes) as requester_wait_time_in_minutes
+        , sum(on_hold_time_in_minutes) as on_hold_time_in_minutes
+    from calendar_minutes
+    group by 1
+)
+select 
+    calendar_minutes_aggregated.ticket_id
+    , calendar_minutes_aggregated.agent_wait_time_in_minutes as agent_wait_time_in_calendar_minutes
+    , business_minutes_aggregated.agent_wait_time_in_minutes as agent_wait_time_in_business_minutes
+    , calendar_minutes_aggregated.requester_wait_time_in_minutes as requester_wait_time_in_calendar_minutes
+    , business_minutes_aggregated.requester_wait_time_in_minutes as requester_wait_time_in_business_minutes
+    , calendar_minutes_aggregated.on_hold_time_in_minutes as on_hold_time_in_calendar_minutes
+    , business_minutes_aggregated.on_hold_time_in_minutes as on_hold_time_in_business_minutes
+from calendar_minutes_aggregated
+left join business_minutes_aggregated
+    on business_minutes_aggregated.ticket_id = calendar_minutes_aggregated.ticket_id
+);


### PR DESCRIPTION
Hi there,

I have recently adapted the queries in this repository for use in my organization's Snowflake data warehouse. This took quite a lot of work, so I wanted to share them here in the hope that someone else may find them useful. I have removed a couple of pieces which are specific to my organization (such as specific schedule IDs or agent filtering), so this should work for any generic Zendesk implementation. We use Zendesk Enterprise with multiple schedules, which is what I have included here.

I'm happy to incorporate feedback, such as changes to directory structure, or anything else.

In addition, I've done my best to validate the results of these queries by comparing against our historical data (previously synced via Stitch) and also by comparing against the Zendesk Ticket Metrics API endpoint. I have a high degree of confidence in the results, and have documented all known caveats in the README, but I would encourage anyone using these queries to do their own double-checking, in case there is some edge case not properly handled, or in case of a different Zendesk configuration.

Thanks a lot!